### PR TITLE
Améliore les performances de l'indexation et de la recherche

### DIFF
--- a/geotribu_cli/constants.py
+++ b/geotribu_cli/constants.py
@@ -72,6 +72,26 @@ class RssItem:
     url: str = None
 
 
+@dataclass
+class MkdocsSearchConfiguration:
+    lang: list
+    separator: str
+
+
+@dataclass
+class MkdocsSearchDocument:
+    title: str
+    text: str
+    location: str
+    tags: list
+
+
+@dataclass
+class MkdocsSearchListing:
+    config: MkdocsSearchConfiguration
+    docs: list[MkdocsSearchDocument]
+
+
 # -- Stand alone execution
 if __name__ == "__main__":
     defaults = GeotribuDefaults()

--- a/geotribu_cli/subcommands/search_image.py
+++ b/geotribu_cli/subcommands/search_image.py
@@ -6,12 +6,12 @@
 
 # standard library
 import argparse
-import json
 import logging
 import sys
 from pathlib import Path
 
 # 3rd party
+import orjson
 from lunr.index import Index
 from rich import print
 from rich.table import Table
@@ -204,8 +204,8 @@ def run(args: argparse.Namespace):
         logger.error(f"{args.local_index_file.resolve()} does not exist")
         sys.exit(f"{args.local_index_file.resolve()} does not exist")
     # loads it
-    with args.local_index_file.open("r") as fd:
-        serialized_idx = json.loads(fd.read())
+    with args.local_index_file.open("rb") as fd:
+        serialized_idx = orjson.loads(fd.read())
 
     # charge l'index sérialisé
     idx = Index.load(serialized_idx.get("index"))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 imagesize>=1.4,<1.5
 lunr[languages]>=0.6,<0.7
+orjson>=3.8,<3.9
 rich_argparse>=0.6,<0.8
 typing-extensions>=4,<5 ; python_version < '3.11'

--- a/tests/dev/dev_filtering_json_ijson.py
+++ b/tests/dev/dev_filtering_json_ijson.py
@@ -1,0 +1,25 @@
+# standard library
+import json
+from pathlib import Path
+
+# 3rd party
+import ijson
+
+local_listing_file = Path().home() / ".geotribu/search/site_content_listing.json"
+
+
+out_file = local_listing_file.with_name(
+    f"{local_listing_file.stem}_filtered_ijson.json"
+)
+
+# with ijson
+with local_listing_file.open(mode="rb") as j:
+
+    objects = ijson.items(j, "docs")
+
+    with out_file.open(mode="wb") as fd:
+        json.dump(
+            tuple(filter(lambda c: c.location.startswith(("article", "rdp")), objects)),
+            fd,
+            separators=(",", ":"),
+        )

--- a/tests/dev/dev_filtering_json_msgspec.py
+++ b/tests/dev/dev_filtering_json_msgspec.py
@@ -1,0 +1,39 @@
+# standard library
+import json
+from pathlib import Path
+
+from msgspec import Struct
+from msgspec.json import decode, encode
+
+local_listing_file = Path().home() / ".geotribu/search/site_content_listing.json"
+
+
+class Configuration(Struct):
+    lang: list
+    separator: str
+
+
+class Document(Struct):
+    title: str
+    text: str
+    location: str
+    tags: list
+
+
+class Listing(Struct):
+    config: Configuration
+    docs: list[Document]
+
+
+with local_listing_file.open("r", encoding="UTF-8") as f:
+    data = decode(f.read(), type=Listing)
+
+# del data["config"]
+
+out_data = tuple(filter(lambda c: c.location.startswith(("article", "rdp")), data.docs))
+
+out_file = local_listing_file.with_name(
+    f"{local_listing_file.stem}_filtered_msgspec.json"
+)
+with out_file.open(mode="w", encoding="UTF-8") as fd:
+    json.dump(encode(out_data), fd, separators=(",", ":"))

--- a/tests/dev/dev_filtering_json_orjson.py
+++ b/tests/dev/dev_filtering_json_orjson.py
@@ -1,0 +1,32 @@
+# standard library
+from pathlib import Path
+
+# 3rd party
+import orjson
+
+local_listing_file = Path().home() / ".geotribu/search/site_content_listing.json"
+
+
+# with json standard lib
+with local_listing_file.open(mode="rb") as j:
+    data: dict = orjson.loads(j.read())
+
+del data["config"]
+
+# print(len(data.get("docs")))
+
+data["docs"] = [
+    d for d in data.get("docs") if d.get("location").startswith(("article", "rdp"))
+]
+
+# data["docs"] = tuple(
+#     filter(lambda c: c.get("location").startswith(("article", "rdp")), data.get("docs"))
+# )
+# print(len(list(ret)))
+# print(len(data.get("docs")))
+
+out_file = local_listing_file.with_name(
+    f"{local_listing_file.stem}_filtered_orjson.json"
+)
+with out_file.open(mode="wb") as fd:
+    fd.write(orjson.dumps(data))

--- a/tests/dev/dev_filtering_json_stdlib.py
+++ b/tests/dev/dev_filtering_json_stdlib.py
@@ -1,0 +1,30 @@
+# standard library
+import json
+from pathlib import Path
+
+local_listing_file = Path().home() / ".geotribu/search/site_content_listing.json"
+
+
+# with json standard lib
+with local_listing_file.open(mode="r", encoding="UTF-8") as j:
+    data: dict = json.loads(j.read())
+
+del data["config"]
+
+# print(len(data.get("docs")))
+
+data["docs"] = [
+    d for d in data.get("docs") if d.get("location").startswith(("article", "rdp"))
+]
+
+# data["docs"] = tuple(
+#     filter(lambda c: c.get("location").startswith(("article", "rdp")), data.get("docs"))
+# )
+# print(len(list(ret)))
+# print(len(data.get("docs")))
+
+out_file = local_listing_file.with_name(
+    f"{local_listing_file.stem}_filtered_stdlib.json"
+)
+with out_file.open(mode="w", encoding="UTF-8") as fd:
+    json.dump(data, fd, separators=(",", ":"))


### PR DESCRIPTION
- utilise [orjson](https://github.com/ijl/orjson) en remplacement de la bibliothèque standard json
- filtre les contenus avant indexation en ne gardant que les articles et revues de presse