### PR TITLE
Commentaires --> Mastodon : gérer le fil de discussion

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -10,6 +10,7 @@
 | `GEOTRIBU_DEFAULT_SUBCOMMAND` | Sous-commande à exécuter par défaut quand on lance le CLI sans argument | | `read-latest` |
 | `GEOTRIBU_IMAGES_DEFAULT_TYPE` | Type d'image sur lequel filtrer. | `--filter-type` de `search-images`  | `None` |
 | `GEOTRIBU_IMAGES_INDEX_EXPIRATION_HOURS` | Nombre d'heures à partir duquel considérer le fichier local comme périmé. | `--expiration-rotating-hours` de `search-images`  | `24` (1 jour) |
+| `GEOTRIBU_MASTODON_STATUS_VISIBILITY` | Visibilité des statuts postés sur Mastodon. Voir [la doc officielle](https://docs.joinmastodon.org/user/posting/#unlisted). |  | `unlisted` |
 | `GEOTRIBU_OPEN_WITH` | Avec quoi ouvrir le contenu. | `--with` de `ouvrir` | `shell` |
 | `GEOTRIBU_PROMPT_AFTER_SEARCH` | Activer/désactiver l'invite pour sélectionner une action à la fin d'une commande de recherche. | `--no-prompt` | `True` |
 | `GEOTRIBU_RESULTATS_FORMAT` | Format de résultat des commandes de recherche | `--format-output` | `table` |

--- a/geotribu_cli/subcommands/comments_broadcast.py
+++ b/geotribu_cli/subcommands/comments_broadcast.py
@@ -204,7 +204,9 @@ def broadcast_to_mastodon(in_comment: Comment, public: bool = True) -> dict:
         request_data["visibility"] = "direct"
     else:
         logger.debug("Comment will be posted as UNLISTED message.")
-        request_data["visibility"] = "unlisted"
+        request_data["visibility"] = getenv(
+            "GEOTRIBU_MASTODON_DEFAULT_VISIBILITY", "unlisted"
+        )
 
     json_data = json.dumps(request_data)
     json_data_bytes = json_data.encode("utf-8")  # needs to be bytes

--- a/geotribu_cli/subcommands/comments_broadcast.py
+++ b/geotribu_cli/subcommands/comments_broadcast.py
@@ -156,6 +156,19 @@ def broadcast_to_mastodon(in_comment: Comment, public: bool = True) -> dict:
         "status": comment_to_media(in_comment=in_comment, media="mastodon"),
         "language": "fr",
     }
+
+    # check if parent comment has been posted
+    if in_comment.parent is not None:
+        comment_parent_broadcasted = comment_already_broadcasted(
+            in_comment=Comment(id=in_comment.parent), media="mastodon"
+        )
+        if (
+            isinstance(comment_already_broadcasted, dict)
+            and "id" in comment_already_broadcasted
+        ):
+            request_data["in_reply_to_id"] = comment_parent_broadcasted.get("id")
+
+    # unlisted or direct
     if not public:
         logger.debug("Comment will be posted as DIRECT message.")
         request_data["visibility"] = "direct"

--- a/geotribu_cli/subcommands/comments_broadcast.py
+++ b/geotribu_cli/subcommands/comments_broadcast.py
@@ -91,7 +91,7 @@ def comment_already_broadcasted(comment_id: int, media: str = "mastodon") -> dic
         # prepare search request
         request_data = {
             "all": ["commentaire"],
-            "lmit": 40,
+            "limit": 40,
             "local": True,
             "since_id": "110549835686856734",
         }


### PR DESCRIPTION
Si le commentaire est une réponse à un autre (le commentaire parenr), vérifier si ce dernier a été publié sur Mastodon et si c'est le cas l'utiliser comme `reply_to`.