### PR TITLE
Améliore la gestion des réponses HTTP 40*

### DIFF
--- a/geotribu_cli/comments/comments_broadcast.py
+++ b/geotribu_cli/comments/comments_broadcast.py
@@ -106,7 +106,7 @@ def comment_already_broadcasted(comment_id: int, media: str = "mastodon") -> dic
             "Content-Type": "application/json; charset=utf-8",
         }
         req = request.Request(
-            f"{defaults_settings.mastodon_base_url}/api/v1/timelines/tag/geotribot",
+            f"{defaults_settings.mastodon_base_url}api/v1/timelines/tag/geotribot",
             method="GET",
             headers=headers,
         )
@@ -133,7 +133,7 @@ def comment_already_broadcasted(comment_id: int, media: str = "mastodon") -> dic
                     f"{comment_id} n'y est pas..."
                 )
                 req = request.Request(
-                    f"{defaults_settings.mastodon_base_url}/api/v1/statuses/"
+                    f"{defaults_settings.mastodon_base_url}api/v1/statuses/"
                     f"{status.get('id')}/context",
                     method="GET",
                     headers=headers,
@@ -220,7 +220,7 @@ def broadcast_to_mastodon(in_comment: Comment, public: bool = True) -> dict:
     }
 
     req = request.Request(
-        f"{defaults_settings.mastodon_base_url}/api/v1/statuses",
+        f"{defaults_settings.mastodon_base_url}api/v1/statuses",
         method="POST",
         headers=headers,
     )

--- a/geotribu_cli/comments/comments_broadcast.py
+++ b/geotribu_cli/comments/comments_broadcast.py
@@ -148,6 +148,10 @@ def comment_already_broadcasted(comment_id: int, media: str = "mastodon") -> dic
                         )
                         return reply_status
 
+    logger.info(
+        f"Le commentaire {comment_id} n'a pas été trouvé. "
+        "Il est donc considéré comme nouveau."
+    )
     return None
 
 
@@ -193,11 +197,17 @@ def broadcast_to_mastodon(in_comment: Comment, public: bool = True) -> dict:
             and "id" in comment_parent_broadcasted
         ):
             print(
-                "Le commentaire parent a été posté précédemment sur Mastodon : "
-                f"{comment_parent_broadcasted.get('url')}. Le commentaire actuel sera "
-                "posté en réponse."
+                f"Le commentaire parent {in_comment.parent}a été posté précédemment sur "
+                f"Mastodon : {comment_parent_broadcasted.get('url')}. Le commentaire "
+                "actuel sera posté en réponse."
             )
             request_data["in_reply_to_id"] = comment_parent_broadcasted.get("id")
+        else:
+            print(
+                f"Le commentaire parent {in_comment.parent} n'a été posté précédemment "
+                "sur Mastodon. Le commentaire actuel sera donc posté comme nouveau fil "
+                "de discussion."
+            )
 
     # unlisted or direct
     if not public:

--- a/geotribu_cli/utils/file_downloader.py
+++ b/geotribu_cli/utils/file_downloader.py
@@ -6,7 +6,6 @@
 # ################################
 
 # standard library
-import json
 import logging
 from http.client import HTTPMessage, HTTPResponse
 from pathlib import Path
@@ -171,15 +170,8 @@ class BetterHTTPErrorProcessor(BaseHandler):
         Returns:
             response object
         """
-        try:
-            decoded_response = json.loads(response.read().decode("utf-8"))
-        except Exception as err:
-            logger.warning(f"L'objet réponse ne semble pas être un JSON valide : {err}")
-            decoded_response = response.read().decode("utf-8")
-
         logger.error(
             f"La requête {request.method} vers {request.full_url} a retourné une erreur "
             f"{code} avec le message : {msg}."
-            f" Détails : {decoded_response}"
         )
         return response


### PR DESCRIPTION
En particulier 401 pour les soucis de jeton dans les appels authentifiés à l'API Mastodon.