### PR TITLE
Utilise le logo dédié

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,9 @@ pygments_style = "sphinx"
 html_baseurl = __about__.__uri_homepage__
 
 # Theme
-html_favicon = "https://cdn.geotribu.fr/img/internal/charte/geotribu_cli_logo_200x200.png"
+html_favicon = (
+    "https://cdn.geotribu.fr/img/internal/charte/geotribu_cli_logo_200x200.png"
+)
 html_logo = "https://cdn.geotribu.fr/img/internal/charte/geotribu_cli_logo_200x200.png"
 
 html_theme = "furo"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,8 +101,8 @@ pygments_style = "sphinx"
 html_baseurl = __about__.__uri_homepage__
 
 # Theme
-html_favicon = "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_orange_LQ.png"
-html_logo = "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
+html_favicon = "https://cdn.geotribu.fr/img/internal/charte/geotribu_cli_logo_200x200.png"
+html_logo = "https://cdn.geotribu.fr/img/internal/charte/geotribu_cli_logo_200x200.png"
 
 html_theme = "furo"
 html_theme_options = {


### PR DESCRIPTION
![geotribu_cli_logo](https://github.com/geotribu/cli/assets/1596222/d561dd80-2dc1-486d-bf1b-fc998bda89a7)

