### PR TITLE
Corrige la comparaison des dates de dernière modification des fichiers selon les systèmes d'exploitation

### DIFF
--- a/geotribu_cli/utils/file_downloader.py
+++ b/geotribu_cli/utils/file_downloader.py
@@ -9,6 +9,7 @@
 import logging
 from http.client import HTTPMessage, HTTPResponse
 from pathlib import Path
+from sys import platform as opersys
 from urllib.error import HTTPError, URLError
 from urllib.request import (
     BaseHandler,
@@ -67,9 +68,18 @@ def download_remote_file_to_local(
         Path: path to the local file (should be the same as local_file_path)
     """
     if local_file_path.exists():
+        # modification date varies depending on operating system: on some systems (like
+        # Unix) creation date is the time of the last metadata change, and, on others
+        # (like Windows), is the creation time for path.
+        if opersys == "win32":
+            mod_date_reference = "m"
+        else:
+            mod_date_reference = "c"
+
         if is_file_older_than(
             local_file_path=local_file_path,
             expiration_rotating_hours=expiration_rotating_hours,
+            dt_reference_mode=mod_date_reference,
         ):
             logger.info(
                 f"Local search index ({local_file_path}) is outdated: "

--- a/geotribu_cli/utils/file_downloader.py
+++ b/geotribu_cli/utils/file_downloader.py
@@ -9,7 +9,6 @@
 import logging
 from http.client import HTTPMessage, HTTPResponse
 from pathlib import Path
-from sys import platform as opersys
 from urllib.error import HTTPError, URLError
 from urllib.request import (
     BaseHandler,
@@ -68,18 +67,9 @@ def download_remote_file_to_local(
         Path: path to the local file (should be the same as local_file_path)
     """
     if local_file_path.exists():
-        # modification date varies depending on operating system: on some systems (like
-        # Unix) creation date is the time of the last metadata change, and, on others
-        # (like Windows), is the creation time for path.
-        if opersys == "win32":
-            mod_date_reference = "m"
-        else:
-            mod_date_reference = "c"
-
         if is_file_older_than(
             local_file_path=local_file_path,
             expiration_rotating_hours=expiration_rotating_hours,
-            dt_reference_mode=mod_date_reference,
         ):
             logger.info(
                 f"Local search index ({local_file_path}) is outdated: "

--- a/geotribu_cli/utils/file_stats.py
+++ b/geotribu_cli/utils/file_stats.py
@@ -10,6 +10,7 @@
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
+from sys import platform as opersys
 from typing import Literal
 
 # ############################################################################
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 def is_file_older_than(
     local_file_path: Path,
     expiration_rotating_hours: int = 24,
-    dt_reference_mode: Literal["c", "m"] = "c",
+    dt_reference_mode: Literal["auto", "creation", "modification"] = "auto",
 ) -> bool:
     """Check if the creation/modification date of the specified file is older than the \
         mount of hours.
@@ -36,14 +37,25 @@ def is_file_older_than(
         local_file_path (Path): local path to the index file
         expiration_rotating_hours (int, optional): number in hours to consider the \
             local file outdated. Defaults to 24.
-        dt_reference_mode (Literal['c', 'm'], optional): reference date type: c for \
-            creation date, m for modification. Defaults to "c".
+        dt_reference_mode (Literal['auto', 'creation', 'modification'], optional):
+            reference date type: auto to handle differences between operating systems,
+            creation for creation date, modification for last modification date.
+            Defaults to "auto".
+
     Returns:
         bool: True if the creation/modification date of the file is older than the \
             specified number of hours.
     """
+    # modification date varies depending on operating system: on some systems (like
+    # Unix) creation date is the time of the last metadata change, and, on others
+    # (like Windows), is the creation time for path.
+    if dt_reference_mode == "auto" and opersys == "win32":
+        dt_reference_mode = "modification"
+    else:
+        dt_reference_mode = "creation"
+
     # get file reference datetime - modification or creation
-    if dt_reference_mode == "m":
+    if dt_reference_mode == "modification":
         f_ref_dt = datetime.fromtimestamp(local_file_path.stat().st_mtime)
         dt_type = "modified"
     else:


### PR DESCRIPTION
Car :

> Return the system's ctime which, on some systems (like Unix) is the time of the last metadata change, and, on others (like Windows), is the creation time for path.

Références :

- https://docs.python.org/fr/3/library/os.path.html#os.path.getctime
- https://stackoverflow.com/questions/237079/how-do-i-get-file-creation-and-modification-date-times