### PR TITLE
security: bump pillow to 10.2 to fix CVE-2022-22817

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,7 @@
 # Testing dependencies
 # --------------------
 
-Pillow>=10.0.1,<11
+Pillow>=10.2,<11
 pytest-cov>=4
 pytest-retry>=1.6
 validators>=0.20,<0.23


### PR DESCRIPTION
Not a real problem since it's just a test dependency. Still here comes the fix for https://github.com/advisories/GHSA-3f63-hfp8-52jq/dependabot?query=user%3Ageotribu

> Pillow through 10.1.0 allows PIL.ImageMath.eval Arbitrary Code Execution via the environment parameter, a different vulnerability than CVE-2022-22817 (which was about the expression parameter).