### PR TITLE
change(comments/broadcast): make mastodon the default targetted social media

### DIFF
--- a/geotribu_cli/comments/comments_broadcast.py
+++ b/geotribu_cli/comments/comments_broadcast.py
@@ -88,7 +88,7 @@ def parser_comments_broadcast(
         default="mastodon",
         dest="broadcast_to",
         help="Canaux (réseaux sociaux) où publier le(s) commentaire(s).",
-        required=True,
+        required=False,
     )
 
     subparser.add_argument(


### PR DESCRIPTION
Now it's possible to simply write: `geotribu comments broadcast -c 475` instead of `geotribu comments broadcast -c 475 -t mastodon`